### PR TITLE
[FireworksRocketProjectile] Fixed constructor argument

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# http://editorconfig.org/
+root = yes
+
+[*]
+indent_size = 4
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+
+[*.yml]
+indent_size = 2
+indent_style = space

--- a/src/pocketmine/entity/projectile/FireworksRocket.php
+++ b/src/pocketmine/entity/projectile/FireworksRocket.php
@@ -36,72 +36,72 @@ use pocketmine\utils\Random;
 
 class FireworksRocket extends Projectile{
 
-    public const NETWORK_ID = EntityIds::FIREWORKS_ROCKET;
+	public const NETWORK_ID = EntityIds::FIREWORKS_ROCKET;
 
-    public const DATA_FIREWORK_ITEM = 16;
+	public const DATA_FIREWORK_ITEM = 16;
 
-    public $width = 0.25;
-    public $height = 0.25;
+	public $width = 0.25;
+	public $height = 0.25;
 
-    protected $gravity = 0.0;
-    protected $drag = 0.1;
+	protected $gravity = 0.0;
+	protected $drag = 0.1;
 
-    /** @var FireworkRocket */
-    public $fireworksItem;
-    /** @var int */
-    public $lifeTime;
+	/** @var FireworkRocket */
+	public $fireworksItem;
+	/** @var int */
+	public $lifeTime;
 
-    public function __construct(Level $level, CompoundTag $nbt, Entity $shootingEntity = null, FireworkRocket $fireworks, Random $random = null){
-        $this->fireworksItem = $fireworks;
-        $random = $random ?? new Random();
+	public function __construct(Level $level, CompoundTag $nbt, FireworkRocket $fireworks, Entity $shootingEntity = null, Random $random = null){
+		$this->fireworksItem = $fireworks;
+		$random = $random ?? new Random();
 
-        $flyTime = 1;
-        $lifeTime = null;
+		$flyTime = 1;
+		$lifeTime = null;
 
-        try{
-            if($nbt->hasTag("Fireworks", CompoundTag::class)){
-                $fireworkCompound = $nbt->getCompoundTag("Fireworks");
-                $flyTime = $fireworkCompound->getByte("Flight", 1);
-                $lifeTime = $fireworkCompound->getInt("LifeTime", 20 * $flyTime + $random->nextBoundedInt(5) + $random->nextBoundedInt(7));
-            }
-        }catch(\Exception $exception){
-            $this->server->getLogger()->debug($exception);
-        }
+		try{
+			if($nbt->hasTag("Fireworks", CompoundTag::class)){
+				$fireworkCompound = $nbt->getCompoundTag("Fireworks");
+				$flyTime = $fireworkCompound->getByte("Flight", 1);
+				$lifeTime = $fireworkCompound->getInt("LifeTime", 20 * $flyTime + $random->nextBoundedInt(5) + $random->nextBoundedInt(7));
+			}
+		}catch(\Exception $exception){
+			$this->server->getLogger()->debug($exception);
+		}
 
-        $this->lifeTime = $lifeTime ?? 20 * $flyTime + $random->nextBoundedInt(5) + $random->nextBoundedInt(7);
+		$this->lifeTime = $lifeTime ?? 20 * $flyTime + $random->nextBoundedInt(5) + $random->nextBoundedInt(7);
 
-        $nbt->setInt("Life", $this->lifeTime);
-        $nbt->setInt("LifeTime", $this->lifeTime);
+		$nbt->setInt("Life", $this->lifeTime);
+		$nbt->setInt("LifeTime", $this->lifeTime);
 
-        parent::__construct($level, $nbt, $shootingEntity);
-    }
+		parent::__construct($level, $nbt, $shootingEntity);
+	}
 
-    protected function initEntity(){
-        $this->setGenericFlag(self::DATA_FLAG_AFFECTED_BY_GRAVITY, true);
-        $this->setGenericFlag(self::DATA_FLAG_HAS_COLLISION, true);
-        $this->propertyManager->setItem(self::DATA_FIREWORK_ITEM, $this->fireworksItem);
+	protected function initEntity(){
+		$this->setGenericFlag(self::DATA_FLAG_AFFECTED_BY_GRAVITY, true);
+		$this->setGenericFlag(self::DATA_FLAG_HAS_COLLISION, true);
+		$this->propertyManager->setItem(self::DATA_FIREWORK_ITEM, $this->fireworksItem);
 
-        parent::initEntity();
-    }
+		parent::initEntity();
+	}
 
-    public function spawnTo(Player $player){
-        $this->setMotion($this->getDirectionVector());
-        $this->level->broadcastLevelSoundEvent($this, LevelSoundEventPacket::SOUND_LAUNCH);
-        parent::spawnTo($player);
-    }
+	public function spawnTo(Player $player){
+		$this->setMotion($this->getDirectionVector());
+		$this->level->broadcastLevelSoundEvent($this, LevelSoundEventPacket::SOUND_LAUNCH);
+		parent::spawnTo($player);
+	}
 
-    public function despawnFromAll(){
-        $this->broadcastEntityEvent(EntityEventPacket::FIREWORK_PARTICLES, 0);
-        parent::despawnFromAll();
-        $this->level->broadcastLevelSoundEvent($this, LevelSoundEventPacket::SOUND_BLAST);
-    }
+	public function despawnFromAll(){
+		$this->broadcastEntityEvent(EntityEventPacket::FIREWORK_PARTICLES, 0);
+		parent::despawnFromAll();
+		$this->level->broadcastLevelSoundEvent($this, LevelSoundEventPacket::SOUND_BLAST);
+	}
 
-    public function entityBaseTick(int $tickDiff = 1) : bool{
-        if($this->lifeTime-- <= 0)
-            $this->flagForDespawn();
-        else
-            return parent::entityBaseTick($tickDiff);
+	public function entityBaseTick(int $tickDiff = 1) : bool{
+		if($this->lifeTime-- <= 0)
+			$this->flagForDespawn();
+		else
+			return parent::entityBaseTick($tickDiff);
 
-        return true;
-    }
+		return true;
+	}
 }

--- a/src/pocketmine/item/FireworkRocket.php
+++ b/src/pocketmine/item/FireworkRocket.php
@@ -34,51 +34,53 @@ use pocketmine\utils\Random;
 
 class FireworkRocket extends Item{
 
-    /** @var float */
-    public $spread = 5.0;
+	/** @var float */
+	public const SPEED = 1.25;
+	/** @var float */
+	public const SPREAD = 6.0;
 
-    public function __construct(int $meta = 0){
-        parent::__construct(self::FIREWORKS, $meta, "Firework Rocket");
-    }
+	public function __construct(int $meta = 0){
+		parent::__construct(self::FIREWORKS, $meta, "Firework Rocket");
+	}
 
-    public function getMaxStackSize() : int{
-        return 16;
-    }
+	public function getMaxStackSize() : int{
+		return 16;
+	}
 
-    public function onActivate(Player $player, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector): bool{
-        $random = new Random();
-        $nbt = FireworksUtils::createNBTforEntity($blockReplace, null, $this, $this->spread, $random);
-        $fireworkRocket = new FireworksRocket($player->level, $nbt, $player, clone $this, $random);
-        $player->level->addEntity($fireworkRocket);
+	public function onActivate(Player $player, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector): bool{
+		$random = new Random();
+		$nbt = FireworksUtils::createNBTforEntity($blockReplace, null, $this, self::SPREAD, $random);
+		$fireworkRocket = new FireworksRocket($player->level, $nbt, clone $this, $player, $random);
+		$player->level->addEntity($fireworkRocket);
 
-        if ($fireworkRocket instanceof Entity){
-            --$this->count;
+		if ($fireworkRocket instanceof Entity){
+			--$this->count;
 
-            $fireworkRocket->spawnToAll();
-            return true;
-        }
+			$fireworkRocket->spawnToAll();
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    public function onClickAir(Player $player, Vector3 $directionVector): bool{
-        if($player->isGliding()){
-            $random = new Random();
-            $motion = $player->getDirectionVector()->add(0,1.2);
-            $nbt = FireworksUtils::createNBTforEntity($player, $motion, $this, $this->spread, $random, $player->getYaw(), $player->getPitch());
-            $fireworkRocket = new FireworksRocket($player->level, $nbt, $player, clone $this, $random);
-            $player->level->addEntity($fireworkRocket);
+	public function onClickAir(Player $player, Vector3 $directionVector): bool{
+		if($player->isGliding()){
+			$random = new Random();
+			$motion = $player->getDirectionVector()->multiply(self::SPEED);
+			$nbt = FireworksUtils::createNBTforEntity($player, $motion, $this, self::SPREAD, $random, $player->getYaw(), $player->getPitch());
+			$fireworkRocket = new FireworksRocket($player->level, $nbt, clone $this, $player, $random);
+			$player->level->addEntity($fireworkRocket);
 
-            if ($fireworkRocket instanceof Entity){
-                --$this->count;
+			if ($fireworkRocket instanceof Entity){
+				--$this->count;
 
-                $fireworkRocket->spawnToAll();
-                $player->setMotion($motion);
-                $fireworkRocket->setMotion($motion->multiply(2.6));
-                return true;
-            }
-        }
+				$fireworkRocket->spawnToAll();
+				$player->setMotion($motion);
+				$fireworkRocket->setMotion($motion->multiply(2.5));
+				return true;
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
1. Since the order of the arguments of Fireworks Rocket (projectile) constructor is incorrect, an error will be generated as it is.
2. Acceleration by fireworks close to single mode when gliding at Elytra
3. For unification of tab / space

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
none

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Change argument of `pocketmine\entity\projectile\FireworksRocket` constructor.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
none

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
I changed the order of the constructors, but it should be a no problem if inform the developper and user.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
none

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
[It works like this](https://www.youtube.com/watch?v=9z7zgQBG6Bo)