### PR TITLE
Added Player->sendBossBar() and Server->broadcastBossBar()

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -38,6 +38,7 @@ use pocketmine\entity\Living;
 use pocketmine\entity\object\ItemEntity;
 use pocketmine\entity\projectile\Arrow;
 use pocketmine\entity\Skin;
+use pocketmine\entity\utils\Bossbar;
 use pocketmine\event\entity\EntityDamageByBlockEvent;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
@@ -361,6 +362,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/** @var int */
 	protected $commandPermission = AdventureSettingsPacket::PERMISSION_NORMAL;
 	protected $keepExperience = false;
+
+    /** @var null|Bossbar */
+    private $bossbar = null;
 
 	/**
 	 * @return TranslationContainer|string
@@ -3411,6 +3415,23 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 		$this->dataPacket($pk);
 	}
+	
+    public function getBossBar(): Bossbar{
+        return $this->bossbar;
+    }
+
+    public function removeBossBar(){
+        if($this->bossbar == null) return;
+        $this->bossbar->hideFrom($this);
+        $this->bossbar = null;
+    }
+
+    public function sendBossBar(string $title, float $health = 0, float $maxHealth = 1){
+        $this->removeBossBar(); // TODO: Allow multiple bossbars, and a way to remove them
+        $bossbar = new Bossbar($title, $health, $maxHealth);
+        $bossbar->showTo($this);
+        $this->bossbar = $bossbar;
+    }
 
 	/**
 	 * Sends a popup message to the player

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1851,6 +1851,34 @@ class Server{
 		return count($recipients);
 	}
 
+    /**
+     * @param string     $title
+     * @param Player[] $recipients
+     * @param float      $health
+     * @param float      $maxHealth
+     *
+     * @return int
+     */
+    public function broadcastBossBar(string $title, array $recipients = null, float $health = 0, float $maxHealth = 1) : int{
+        if(!is_array($recipients)){
+            /** @var Player[] $recipients */
+            $recipients = [];
+
+            foreach($this->pluginManager->getPermissionSubscriptions(self::BROADCAST_CHANNEL_USERS) as $permissible){
+                if($permissible instanceof Player and $permissible->hasPermission(self::BROADCAST_CHANNEL_USERS)){
+                    $recipients[spl_object_hash($permissible)] = $permissible; // do not send messages directly, or some might be repeated
+                }
+            }
+        }
+
+        /** @var Player[] $recipients */
+        foreach($recipients as $recipient){
+            $recipient->sendBossBar($title, $health, $maxHealth);
+        }
+
+        return count($recipients);
+    }
+
 	/**
 	 * @param string   $tip
 	 * @param Player[] $recipients


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This br simplifies the BossBar API even more

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Player->getBossBar() Returns null or \pocketmine\utils\Bossbar instance of their current BossBar
Player->removeBossBar() Removes the current BossBar from the player, if not null
Player->sendBossBar(string $title, float $health, float $maxHealth) Send a BossBar to a player
Server->broadcastBossBar(string $title, Player[] $recipients, float $health, float $maxHealth) Send a BossBar to multiple people

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| foo.bar | Foo bar |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->