### PR TITLE
Fixing chat crash symbol

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2208,7 +2208,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		foreach(explode("\n", $message) as $messagePart){
 			$messagePart = trim($messagePart);
 			if($messagePart !== "" and strlen($messagePart) <= 255 and $this->messageCounter-- > 0){
-				$this->server->getPluginManager()->callEvent($ev = new PlayerChatEvent($this, $messagePart));
+				$this->server->getPluginManager()->callEvent($ev = new PlayerChatEvent($this, utf8_encode($messagePart)));
 				if(!$ev->isCancelled()){
 					$this->server->broadcastMessage($this->getServer()->getLanguage()->translateString($ev->getFormat(), [$ev->getPlayer()->getDisplayName(), $ev->getMessage()]), $ev->getRecipients());
 				}


### PR DESCRIPTION
Encode text in utf-8 to avoid annoying crash symbols that make windows10 users crash, it has been on for a long time but never fixed by mojang.

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->