### PR TITLE
Fix crash symbols on signs

### DIFF
--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -70,16 +70,16 @@ class Sign extends Spawnable{
 	 */
 	public function setText(?string $line1 = "", ?string $line2 = "", ?string $line3 = "", ?string $line4 = "") : void{
 		if($line1 !== null){
-			$this->text[0] = $line1;
+			$this->text[0] = utf8_encode($line1);
 		}
 		if($line2 !== null){
-			$this->text[1] = $line2;
+			$this->text[1] = utf8_encode($line2);
 		}
 		if($line3 !== null){
-			$this->text[2] = $line3;
+			$this->text[2] = utf8_encode($line3);
 		}
 		if($line4 !== null){
-			$this->text[3] = $line4;
+			$this->text[3] = utf8_encode($line4);
 		}
 
 		$this->onChanged();


### PR DESCRIPTION
Sometimes Trollers put crash symbols on signs and make windows 10 users crash....

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->