### PR TITLE
Remove stupid Block Palette Randomizing

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/types/RuntimeBlockMapping.php
+++ b/src/pocketmine/network/mcpe/protocol/types/RuntimeBlockMapping.php
@@ -50,7 +50,7 @@ final class RuntimeBlockMapping{
 	public static function init() : void{
 		$legacyIdMap = json_decode(file_get_contents(\pocketmine\RESOURCE_PATH . "legacy_id_map.json"), true);
 
-		self::$bedrockKnownStates = self::randomizeTable(json_decode(file_get_contents(\pocketmine\RESOURCE_PATH . "runtimeid_table.json"), true));
+		self::$bedrockKnownStates = json_decode(file_get_contents(\pocketmine\RESOURCE_PATH . "runtimeid_table.json"), true);
 
 		foreach(self::$bedrockKnownStates as $k => $obj){
 			//this has to use the json offset to make sure the mapping is consistent with what we send over network, even though we aren't using all the entries
@@ -59,23 +59,6 @@ final class RuntimeBlockMapping{
 			}
 			self::registerMapping($k, $legacyIdMap[$obj["name"]], $obj["data"]);
 		}
-	}
-
-	/**
-	 * Randomizes the order of the runtimeID table to prevent plugins relying on them.
-	 * Plugins shouldn't use this stuff anyway, but plugin devs have an irritating habit of ignoring what they
-	 * aren't supposed to do, so we have to deliberately break it to make them stop.
-	 *
-	 * @param array $table
-	 *
-	 * @return array
-	 */
-	private static function randomizeTable(array $table) : array{
-		$postSeed = mt_rand(); //save a seed to set afterwards, to avoid poor quality randoms
-		mt_srand(getmypid() ?: 0); //Use a seed which is the same on all threads. This isn't a secure seed, but we don't care.
-		shuffle($table);
-		mt_srand($postSeed); //restore a good quality seed that isn't dependent on PID
-		return $table;
 	}
 
 	/**


### PR DESCRIPTION
This was added beceause of the plugin devs stupidity. It's time to remove this as it causes some strange bugs on using some type of proxys due to the difference of each block palette under itself

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
