### PR TITLE
Multi Plugins Folder Support

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1789,7 +1789,8 @@ class Server{
 
 			$this->queryRegenerateTask = new QueryRegenerateEvent($this, 5);
 
-			$this->pluginManager->loadPlugins($this->pluginPath);
+			$additionalPluginDirs = $this->getAdditionalPluginDirs();
+			$this->pluginManager->loadPlugins($this->pluginPath, $additionalPluginDirs);
 
 			$this->enablePlugins(PluginLoadOrder::STARTUP);
 
@@ -2167,7 +2168,8 @@ class Server{
 
 		$this->pluginManager->registerInterface(new PharPluginLoader($this->autoloader));
 		$this->pluginManager->registerInterface(new ScriptPluginLoader());
-		$this->pluginManager->loadPlugins($this->pluginPath);
+        $additionalPluginDirs = $this->getAdditionalPluginDirs();
+        $this->pluginManager->loadPlugins($this->pluginPath, $additionalPluginDirs);
 		$this->enablePlugins(PluginLoadOrder::STARTUP);
 		$this->enablePlugins(PluginLoadOrder::POSTWORLD);
 		TimingsHandler::reload();
@@ -2625,6 +2627,9 @@ class Server{
 		//TODO: add raw packet events
 	}
 
+    private function getAdditionalPluginDirs(){
+        return $this->getAltayProperty("additional-plugin-dirs");
+    }
 
 	/**
 	 * Tries to execute a server tick

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1789,8 +1789,11 @@ class Server{
 
 			$this->queryRegenerateTask = new QueryRegenerateEvent($this, 5);
 
-			$additionalPluginDirs = $this->getAdditionalPluginDirs();
-			$this->pluginManager->loadPlugins($this->pluginPath, $additionalPluginDirs);
+			$this->pluginManager->loadPlugins($this->pluginPath);
+			
+			foreach($this->getAdditionalPluginDirs() as $path){
+				$this->pluginManager->loadPlugins($path);
+			}
 
 			$this->enablePlugins(PluginLoadOrder::STARTUP);
 
@@ -2168,8 +2171,12 @@ class Server{
 
 		$this->pluginManager->registerInterface(new PharPluginLoader($this->autoloader));
 		$this->pluginManager->registerInterface(new ScriptPluginLoader());
-        $additionalPluginDirs = $this->getAdditionalPluginDirs();
-        $this->pluginManager->loadPlugins($this->pluginPath, $additionalPluginDirs);
+        $this->pluginManager->loadPlugins($this->pluginPath);
+		
+		foreach($this->getAdditionalPluginDirs() as $path){
+			$this->pluginManager->loadPlugins($path);
+		}
+		
 		$this->enablePlugins(PluginLoadOrder::STARTUP);
 		$this->enablePlugins(PluginLoadOrder::POSTWORLD);
 		TimingsHandler::reload();
@@ -2627,8 +2634,8 @@ class Server{
 		//TODO: add raw packet events
 	}
 
-    private function getAdditionalPluginDirs(){
-        return $this->getAltayProperty("additional-plugin-dirs");
+    private function getAdditionalPluginDirs() : array{
+        return $this->getAltayProperty("additional-plugin-dirs", []);
     }
 
 	/**

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -237,23 +237,8 @@ class PluginManager{
 			$loaders = $this->fileAssociations;
 		}
 
-        $directories[] = $directory;
-        $files = [];
-        if(is_array($additionalDirectories)){
-            foreach($additionalDirectories as $directory_){
-                if(is_dir($directory_)){
-                    $directories[] = $directory_;
-                }
-            }
-        }
-        foreach($directories as $directory_){
-            foreach(new \DirectoryIterator($directory_) as $file){
-                $files[] = $file->getRealPath();
-            }
-        }
-
         foreach($loaders as $loader){
-            foreach($files as $file){
+			foreach(new \DirectoryIterator($directory) as $file){
 				if($file === "." or $file === ".."){
 					continue;
 				}

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -236,8 +236,24 @@ class PluginManager{
 		}else{
 			$loaders = $this->fileAssociations;
 		}
-		foreach($loaders as $loader){
-			foreach(new \DirectoryIterator($directory) as $file){
+
+        $directories[] = $directory;
+        $files = [];
+        if(is_array($additionalDirectories)){
+            foreach($additionalDirectories as $directory_){
+                if(is_dir($directory_)){
+                    $directories[] = $directory_;
+                }
+            }
+        }
+        foreach($directories as $directory_){
+            foreach(new \DirectoryIterator($directory_) as $file){
+                $files[] = $file->getRealPath();
+            }
+        }
+
+        foreach($loaders as $loader){
+            foreach($files as $file){
 				if($file === "." or $file === ".."){
 					continue;
 				}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This improvement lets you to load plugins from different folders. PluginManager is able to scan additional folders for plugins.

A little improvement for who has complex plugins folder as workspace. Aimed developers with multi plugin folders that don't want to waste time on testing. But it's usable for any reason.

### Usage
add your workspace to altay.yml like
```
additional-plugin-dirs:
  - "C:/Users/Ataberk/PhpstormProjects/TurkMCPE-Plugins"
  - "C:/Users/Ataberk/Desktop/Additional-Plugins"
```

## Changes
No existed function name change. loadPlugins() usage changed a bit.

## Backwards compatibility
Completely backward compatible

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

Works with PHAR too.

![Untitled](https://user-images.githubusercontent.com/10375421/59641063-d6ed1a00-9168-11e9-9425-24438ee4d9c0.png)
