### PR TITLE
MeleeAttackBehavior: getTargetEntity() may return null

### DIFF
--- a/src/pocketmine/entity/behavior/MeleeAttackBehavior.php
+++ b/src/pocketmine/entity/behavior/MeleeAttackBehavior.php
@@ -73,6 +73,10 @@ class MeleeAttackBehavior extends Behavior{
 
 	public function onTick() : void{
 		$target = $this->mob->getTargetEntity();
+		
+		if($target === null){
+			return;
+		}
 
 		$distanceToPlayer = $this->mob->distanceSquared($target);
 


### PR DESCRIPTION
Error: Argument 1 passed to pocketmine\math\Vector3::distanceSquared() must be an instance of pocketmine\math\Vector3, null given, called in phar:///home/ubuntu/Altay/PocketMine-MP.phar/src/pocketmine/entity/behavior/MeleeAttackBehavior.php on line 77