### PR TITLE
Slime: Use the correct NBT tag

### DIFF
--- a/src/pocketmine/entity/hostile/Slime.php
+++ b/src/pocketmine/entity/hostile/Slime.php
@@ -42,6 +42,7 @@ use pocketmine\level\biome\Biome;
 use pocketmine\level\generator\Flat;
 use pocketmine\level\particle\GenericParticle;
 use pocketmine\level\particle\Particle;
+use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
 use pocketmine\Player;
@@ -79,7 +80,11 @@ class Slime extends Monster{
 		$this->moveHelper = new EntitySlimeMoveHelper($this);
 
 		if($this->namedtag->hasTag("Size", IntTag::class)){
+			// Before Altay used IntTag.
 			$this->setSlimeSize($this->namedtag->getInt("Size"));
+			$this->namedtag->removeTag("Size");
+		}elseif($this->namedtag->hasTag("Size", ByteTag::class)){
+			$this->setSlimeSize($this->namedtag->getByte("Size"));
 		}else{
 			$i = $this->random->nextBoundedInt(3);
 
@@ -120,7 +125,7 @@ class Slime extends Monster{
 	public function saveNBT() : void{
 		parent::saveNBT();
 
-		$this->namedtag->setInt("Size", $this->getSlimeSize());
+		$this->namedtag->setByte("Size", $this->getSlimeSize());
 		$this->namedtag->setByte("wasOnGround", intval($this->wasOnGround));
 	}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
If you put the world with a single game(LevelDB) - its saving stops the server. This Pull Request fixes this.

The problem was that Slime used an untrue NBT tag.

### Relevant issues
<!-- List relevant issues here -->
No

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Unchanged

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
The server does not stop when the vanilla world is saved.