### PR TITLE
Fixed problems with empty skin geometry

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/types/SkinData.php
+++ b/src/pocketmine/network/mcpe/protocol/types/SkinData.php
@@ -65,7 +65,7 @@ class SkinData{
 	/** @var SkinImage */
 	private $capeImage;
 	/** @var string */
-	private $geometryData;
+	private $geometryData = "";
 	/** @var string */
 	private $animationData;
 	/** @var bool */
@@ -96,7 +96,9 @@ class SkinData{
 		$this->skinImage = $skinImage;
 		$this->animations = $animations;
 		$this->capeImage = $capeImage;
-		$this->geometryData = json_encode((new CommentedJsonDecoder())->decode($geometryData));
+		if($geometryData !== ""){
+			$this->geometryData = json_encode((new CommentedJsonDecoder())->decode($geometryData));
+		}
 		$this->animationData = $animationData;
 		$this->premium = $premium;
 		$this->persona = $persona;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Client can send empty geometry data, if uses the "imported" skins.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
See Altay discord channel named `bugs`.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

![PicsArt_12-11-05 16 19](https://user-images.githubusercontent.com/55767127/70628905-14bf8c80-1c3a-11ea-8a92-4ae342a2f433.jpg)
