### PR TITLE
Small fixes to Hopper Tile

### DIFF
--- a/src/pocketmine/tile/Hopper.php
+++ b/src/pocketmine/tile/Hopper.php
@@ -26,6 +26,7 @@ namespace pocketmine\tile;
 
 use pocketmine\entity\Entity;
 use pocketmine\entity\object\ItemEntity;
+use pocketmine\inventory\FurnaceInventory;
 use pocketmine\inventory\HopperInventory;
 use pocketmine\inventory\InventoryHolder;
 use pocketmine\level\Level;
@@ -126,7 +127,12 @@ class Hopper extends Spawnable implements Container, Nameable, InventoryHolder{
 	}
 
 	public function isFull() : bool{
-		return count($this->inventory->getContents()) === $this->inventory->getSize();
+		foreach($this->inventory->getContents() as $slot => $item){
+			if($item->getMaxStackSize() !== $item->getCount()){
+				return false;
+			}
+		}
+		return true;
 	}
 
 	public function transferItemOut() : bool{
@@ -160,6 +166,12 @@ class Hopper extends Spawnable implements Container, Nameable, InventoryHolder{
 		if($tile instanceof InventoryHolder){
 			$inv = $tile->getInventory();
 			foreach($inv->getContents() as $slot => $item){
+
+				if($inv instanceof FurnaceInventory){
+					//So only results of Furnaces go trough
+					if($slot !== 2) continue;
+				}
+
 				$item->setCount(1);
 
 				if($this->inventory->canAddItem($item)){


### PR DESCRIPTION
Added check for furnace so hopper can only take the results of the furnace and won't take any fuel.

Fixed isFull() function by checking by max stackabe size instead of checking if all inventory spaces where used.
