### PR TITLE
fixing squid spawning

### DIFF
--- a/src/pocketmine/entity/Mob.php
+++ b/src/pocketmine/entity/Mob.php
@@ -348,7 +348,8 @@ abstract class Mob extends Living{
 	 * @return bool
 	 */
 	public function canSpawnHere() : bool{
-		return parent::canSpawnHere() and $this->getBlockPathWeight($this) > 0;
+		return parent::canSpawnHere();
+		#return parent::canSpawnHere() and $this->getBlockPathWeight($this) > 0;
 	}
 
 	public function moveWithHeading(float $strafe, float $forward){

--- a/src/pocketmine/level/AnimalSpawner.php
+++ b/src/pocketmine/level/AnimalSpawner.php
@@ -79,7 +79,7 @@ class AnimalSpawner{
 					}));
 					$k4 = $creatureType->getMaxSpawn() * count($eligibleChunks) / self::MAX_MOBS;
 
-					if($j4 <= $k4){
+					if($j4 < $k4){
 						foreach($eligibleChunks as $chunkHash){
 							Level::getXZ($chunkHash, $cx, $cz);
 							if(count($level->getChunkEntities($cx, $cz)) === 0){


### PR DESCRIPTION
This functionality:
`$this->getBlockPathWeight`

Will always return false because this:

```
public function getBlockPathWeight(Vector3 $pos) : float{
  return 0.0;
}
```
always returns 0.

Ignoring this check makes squids spawn normally again
