### PR TITLE
Now totem can be used in offhand

### DIFF
--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -742,7 +742,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 		$type = $source->getCause();
 		if($type !== EntityDamageEvent::CAUSE_SUICIDE and $type !== EntityDamageEvent::CAUSE_VOID
-			and $this->inventory->getItemInHand() instanceof Totem){ //TODO: check offhand as well (when it's implemented)
+			and ($this->inventory->getItemInHand() instanceof Totem or $this->offHandInventory->getItemInOffHand() instanceof Totem)){ //TODO: check offhand as well (when it's implemented)
 
 			$compensation = $this->getHealth() - $source->getFinalDamage() - 1;
 			if($compensation < 0){
@@ -764,10 +764,16 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 			$this->broadcastEntityEvent(ActorEventPacket::CONSUME_TOTEM);
 			$this->level->broadcastLevelEvent($this->add(0, $this->eyeHeight, 0), LevelEventPacket::EVENT_SOUND_TOTEM);
 
-			$hand = $this->inventory->getItemInHand();
+			$hand = $this->offHandInventory->getItemInOffHand();
 			if($hand instanceof Totem){
 				$hand->pop(); //Plugins could alter max stack size
-				$this->inventory->setItemInHand($hand);
+				$this->offHandInventory->setItemInOffHand($hand);
+			}else{
+				$hand = $this->inventory->getItemInHand();
+				if($hand instanceof Totem){
+					$hand->pop();
+					$this->inventory->setItemInHand($hand);
+				}
 			}
 		}
 	}

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -742,7 +742,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 		$type = $source->getCause();
 		if($type !== EntityDamageEvent::CAUSE_SUICIDE and $type !== EntityDamageEvent::CAUSE_VOID
-			and ($this->inventory->getItemInHand() instanceof Totem or $this->offHandInventory->getItemInOffHand() instanceof Totem)){ //TODO: check offhand as well (when it's implemented)
+			and ($this->inventory->getItemInHand() instanceof Totem or $this->offHandInventory->getItemInOffHand() instanceof Totem)){
 
 			$compensation = $this->getHealth() - $source->getFinalDamage() - 1;
 			if($compensation < 0){


### PR DESCRIPTION
## Introduction
Now you can put totem to offhand and not die.

### Relevant issues
Idk.

## Changes
### API changes
Without API changes.

### Behavioural changes
No behavioural changes in this PR.

## Backwards compatibility
If someone create plugin that work with offhand and do something with inventory - he/she should also check offhand-inventory when player takes damage.

## Tests
You can test this in game.
