### PR TITLE
Fix Items are black in the Offhand

### DIFF
--- a/src/pocketmine/inventory/PlayerOffHandInventory.php
+++ b/src/pocketmine/inventory/PlayerOffHandInventory.php
@@ -56,6 +56,7 @@ class PlayerOffHandInventory extends BaseInventory{
 
 	public function setItemInOffHand(Item $item) : void{
 		$this->setItem(0, $item);
+		$this->holder->getDataPropertyManager()->setByte(Player::DATA_COLOR,Player::DATA_TYPE_BYTE);
 	}
 
 	public function getItemInOffHand() : Item{


### PR DESCRIPTION
Now Arrows aren't black in the Offhand

## Introduction
Items are black in the Offhand

## Tests
I test this change on my own Test Server and now I can see the color of the items in the Offhand
