### PR TITLE
supported PHP8.0

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3405,7 +3405,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		if($packet->originData->type !== CommandOriginData::ORIGIN_PLAYER) return false;
 
 		$command = $packet->command;
-		if($command{0} != "/") return false;
+		if($command[0] != "/") return false;
 
 		$ev = new PlayerCommandPreprocessEvent($this, $command);
 		$ev->call();

--- a/src/pocketmine/command/Command.php
+++ b/src/pocketmine/command/Command.php
@@ -82,7 +82,7 @@ abstract class Command{
 	 * @param CommandParameter[][] $overloads
 	 */
 	public function __construct(string $name, string $description = "", string $usageMessage = null, array $aliases = [], ?array $overloads = null){
-		if(strlen($description) > 0 and $description{0} == '%'){
+		if(strlen($description) > 0 and $description[0] == '%'){
 			$description = Server::getInstance()->getLanguage()->translateString($description);
 		}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Some syntax is now compatible with php8.0.  
This makes it possible to run Altay even with a bin of php8.0.  
## changed
The change is a syntax change that is no longer supported in php8.0.   
Array and string offset access syntax with curly braces is deprecated.


